### PR TITLE
Add Terragon setup script

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -3,6 +3,5 @@
 # This script runs when your sandbox environment starts
 
 sudo apt update && sudo apt install -y golang-go
-go
 
 echo "Setup complete!"

--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# terragon-setup.sh - Custom setup script for your Terragon environment
+# This script runs when your sandbox environment starts
+
+sudo apt update && sudo apt install -y golang-go
+go
+
+echo "Setup complete!"


### PR DESCRIPTION
## Summary

Adds the `terragon-setup.sh` script that runs when Terragon sandboxes are created for this repository.

## Changes

- Created `terragon-setup.sh` with custom setup commands

## Test plan

The setup script has been tested in a Terragon sandbox and runs successfully.

---
Created via [Terragon](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback