### PR TITLE
Fix image processing to respect custom HTTP client

### DIFF
--- a/postprocessing/postprocessing.go
+++ b/postprocessing/postprocessing.go
@@ -23,11 +23,11 @@ func ProcessArticle(resp *http.Response, excludeImages bool) (*readability.Artic
 // ProcessArticleWithClient handles the complete post-processing pipeline for articles with custom HTTP client
 func ProcessArticleWithClient(resp *http.Response, excludeImages bool, client *http.Client) (*readability.Article, string, int, error) {
 	ctx := context.Background()
-	return ProcessArticleWithContext(ctx, resp, excludeImages)
+	return ProcessArticleWithContext(ctx, resp, excludeImages, client)
 }
 
 // handles the complete post-processing pipeline with context support
-func ProcessArticleWithContext(ctx context.Context, resp *http.Response, excludeImages bool) (*readability.Article, string, int, error) {
+func ProcessArticleWithContext(ctx context.Context, resp *http.Response, excludeImages bool, client *http.Client) (*readability.Article, string, int, error) {
 	// Parse webpage using readability
 	article, err := readability.FromReader(resp.Body, resp.Request.URL)
 	if err != nil {
@@ -57,7 +57,7 @@ func ProcessArticleWithContext(ctx context.Context, resp *http.Response, exclude
 	}
 
 	// Post-process the article content
-	processedArticle, imageCount, err := processContent(&article, resp.Request.URL, excludeImages, nil)
+	processedArticle, imageCount, err := processContent(&article, resp.Request.URL, excludeImages, client)
 	if err != nil {
 		return nil, "", 0, fmt.Errorf("failed to post-process article: %v", err)
 	}

--- a/retrieval.go
+++ b/retrieval.go
@@ -96,7 +96,7 @@ func retrieveContent(ctx context.Context, input string, forceScrapingBee bool) (
 func postProcessContent(ctx context.Context, resp *http.Response, excludeImages bool) (*readability.Article, string, string, int, int, string, error) {
 	defer resp.Body.Close()
 
-	article, filename, imageCount, err := postprocessing.ProcessArticleWithContext(ctx, resp, excludeImages)
+	article, filename, imageCount, err := postprocessing.ProcessArticleWithContext(ctx, resp, excludeImages, nil)
 	if err != nil {
 		return nil, "", "", 0, 0, "", fmt.Errorf("failed to process article: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Propagate custom HTTP clients through postprocessing so image downloads use provided transport
- Update retrieval to call new context-aware function signature

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689768b80d4083299a8635fe70248084