### PR TITLE
refactor: extract file repository

### DIFF
--- a/internal/repositories/file_repository.go
+++ b/internal/repositories/file_repository.go
@@ -1,0 +1,57 @@
+package repositories
+
+import (
+	"os"
+	"path/filepath"
+	"text/template"
+
+	readability "github.com/go-shiori/go-readability"
+)
+
+type FileRepository interface {
+	SaveArticle(article *readability.Article, path string) error
+}
+
+type localFileRepository struct{}
+
+func NewLocalFileRepository() FileRepository {
+	return &localFileRepository{}
+}
+
+type htmlData struct {
+	Title   string
+	Content string
+	Author  string
+}
+
+const htmlTemplate = `<!DOCTYPE html>
+<html>
+<head>
+        <title>{{.Title}}</title>
+        <meta name="author" content="{{.Author}}">
+</head>
+<body>
+        {{.Content}}
+</body>
+</html>
+`
+
+func (r *localFileRepository) SaveArticle(article *readability.Article, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0770); err != nil {
+		return err
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	t := template.Must(template.New("html").Parse(htmlTemplate))
+	data := htmlData{
+		Title:   article.Title,
+		Author:  article.Byline,
+		Content: article.Content,
+	}
+	return t.Execute(file, data)
+}

--- a/retrieval.go
+++ b/retrieval.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/abadojack/whatlanggo"
 	readability "github.com/go-shiori/go-readability"
+	"github.com/yfzhou0904/go-to-kindle/internal/repositories"
 	"github.com/yfzhou0904/go-to-kindle/postprocessing"
 	"github.com/yfzhou0904/go-to-kindle/retrieval"
 	"github.com/yfzhou0904/go-to-kindle/util"
@@ -119,13 +120,8 @@ func postProcessContent(ctx context.Context, resp *http.Response, excludeImages 
 	}
 
 	archivePath := filepath.Join(util.BaseDir(), "archive", filename)
-	_, err = createFile(archivePath)
-	if err != nil {
-		return nil, "", "", 0, 0, "", fmt.Errorf("failed to create archive file: %v", err)
-	}
-
-	err = writeToFile(article, archivePath)
-	if err != nil {
+	repo := repositories.NewLocalFileRepository()
+	if err := repo.SaveArticle(article, archivePath); err != nil {
 		return nil, "", "", 0, 0, "", fmt.Errorf("failed to write to archive file: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- introduce a FileRepository interface with a local implementation
- use the repository to save articles instead of ad-hoc file helpers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68981edc56c0832980fd39f7885080e0