### PR TITLE
Handle Substack images with data-attrs

### DIFF
--- a/postprocessing_test/expected_outputs/substack_image_expected.json
+++ b/postprocessing_test/expected_outputs/substack_image_expected.json
@@ -1,0 +1,16 @@
+{
+  "testName": "substack_image",
+  "inputFile": "html_samples/substack_image.html",
+  "baseURL": "https://example.com/substack",
+  "excludeImages": false,
+  "expectedImageCount": 1,
+  "mustNotContain": [
+    "srcset",
+    "loading",
+    "data-attrs"
+  ],
+  "mustContain": [
+    "Intro text before image.",
+    "data:image/png;base64,"
+  ]
+}

--- a/postprocessing_test/html_samples/substack_image.html
+++ b/postprocessing_test/html_samples/substack_image.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head><title>Substack Image Article</title></head>
+<body>
+<p>Intro text before image.</p>
+<div>
+  <figure><a target="_blank" href="https://substackcdn.com/image/fetch/placeholder.png">
+      <div>
+        <picture>
+          <source type="image/webp" srcset="https://substackcdn.com/image/fetch/placeholder.png 424w, https://substackcdn.com/image/fetch/placeholder.png 848w">
+          <img src="https://substackcdn.com/image/fetch/placeholder.png" width="1456" height="762"
+            data-attrs='{"src":"https://substack-post-media.s3.amazonaws.com/public/images/sample.png","srcNoWatermark":null}'
+            alt="Substack image" srcset="https://substackcdn.com/image/fetch/placeholder.png 424w, https://substackcdn.com/image/fetch/placeholder.png 848w" sizes="100vw" loading="lazy" />
+        </picture>
+      </div>
+    </a></figure>
+</div>
+<p>More text after image.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- parse `data-attrs` JSON to extract real image URLs used by Substack
- prefer those URLs when processing `<picture>` and `<img>` tags and strip the `data-attrs` attribute
- add regression test covering Substack-style image markup

## Testing
- `go test ./... -run TestProcessArticle_FromConfig -v`
- `go test ./postprocessing -run TestProcessArticle_Basic -v`


------
https://chatgpt.com/codex/tasks/task_e_68b92c1e8f5c83298c09bb02373d8b84