### PR TITLE
Center images in generated HTML

### DIFF
--- a/internal/repositories/file_repository.go
+++ b/internal/repositories/file_repository.go
@@ -29,6 +29,9 @@ const htmlTemplate = `<!DOCTYPE html>
 <head>
         <title>{{.Title}}</title>
         <meta name="author" content="{{.Author}}">
+       <style>
+               img { display: block; margin-left: auto; margin-right: auto; }
+       </style>
 </head>
 <body>
         {{.Content}}

--- a/postprocessing/images.go
+++ b/postprocessing/images.go
@@ -403,6 +403,8 @@ func removeImageAttributes(s *goquery.Selection) {
 	s.RemoveAttr("loading")
 	s.RemoveAttr("width")
 	s.RemoveAttr("height")
+	s.RemoveAttr("style")
+	s.RemoveAttr("class")
 
 	// Remove WordPress-specific data attributes
 	s.RemoveAttr("data-orig-size")


### PR DESCRIPTION
## Summary
- Strip `style` and `class` from downloaded images to avoid conflicting alignment
- Inject CSS to center images in rendered HTML

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8f517c0448329a6fc60ab1200f677