### PR TITLE
Display original URL on retrieval failure

### DIFF
--- a/tui.go
+++ b/tui.go
@@ -328,9 +328,10 @@ func (m model) View() string {
 	case completionScreen:
 		if m.err != nil {
 			return fmt.Sprintf(
-				"%s\n\n%s\n\n%s\n",
+				"%s\n\n%s\n\n%s\n\n%s\n",
 				errorStyle.Render("❌ Error"),
 				m.err.Error(),
+				subtleStyle.Render(fmt.Sprintf("Original URL: %s", m.urlInput.Value())),
 				subtleStyle.Render("Press Enter to send another • Esc/Ctrl+C to quit"),
 			)
 		} else {


### PR DESCRIPTION
## Summary
- Expose the original URL on the error screen so users can copy it after a failed retrieval.

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be4b23de9c8329abc8d6158d6ef061