### PR TITLE
Use library-only parsing for terminal-dragged file paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,9 @@ require (
 	github.com/mattn/go-ieproxy v0.0.12
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	golang.org/x/image v0.31.0
+	golang.org/x/net v0.44.0
 	howett.net/plist v1.0.0
+	mvdan.cc/sh/v3 v3.12.0
 )
 
 require (
@@ -44,7 +46,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/net v0.44.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/go-json-experiment/json v0.0.0-20250910080747-cc2cfa0554c3 h1:02WINGfSX5w0Mn+F28UyRoSt9uvMhKguwWMlOAh6U/0=
 github.com/go-json-experiment/json v0.0.0-20250910080747-cc2cfa0554c3/go.mod h1:uNVvRXArCGbZ508SxYYTC5v1JWoz2voff5pm25jU1Ok=
+github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
+github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c h1:wpkoddUomPfHiOziHZixGO5ZBS73cKqVzZipfrLmO1w=
 github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c/go.mod h1:oVDCh3qjJMLVUSILBRwrm+Bc6RNXGZYtoh9xdvf1ffM=
 github.com/go-shiori/go-readability v0.0.0-20250217085726-9f5bf5ca7612 h1:BYLNYdZaepitbZreRIa9xeCQZocWmy/wj4cGIH0qyw0=
@@ -52,7 +54,13 @@ github.com/gobwas/ws v1.4.0/go.mod h1:G3gNqMNtPppf5XUz7O4shetPpcZ1VJ7zt18dlUeakr
 github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f h1:3BSP1Tbs2djlpprl7wCLuiqMaUh5SJkkzI2gDs+FgLs=
 github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f/go.mod h1:Pcatq5tYkCW2Q6yrR2VRHlbHpZ/R4/7qyL1TCF7vl14=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kULo2bwGEkFvCePZ3qHDDTC3/J9Swo=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
@@ -82,6 +90,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
@@ -173,3 +183,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
 howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
+mvdan.cc/sh/v3 v3.12.0 h1:ejKUR7ONP5bb+UGHGEG/k9V5+pRVIyD+LsZz7o8KHrI=
+mvdan.cc/sh/v3 v3.12.0/go.mod h1:Se6Cj17eYSn+sNooLZiEUnNNmNxg0imoYlTu4CyaGyg=

--- a/retrieval.go
+++ b/retrieval.go
@@ -13,6 +13,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"mvdan.cc/sh/v3/shell"
+
 	"github.com/abadojack/whatlanggo"
 	readability "github.com/go-shiori/go-readability"
 	"github.com/yfzhou0904/go-to-kindle/internal/repositories"
@@ -157,32 +159,13 @@ func postProcessContent(ctx context.Context, input *InputResult, excludeImages b
 // takes a file path string supplied by user dragging a file into terminal, or via copy-paste
 // returns a normalized absolute path that can be used to open the file
 func normalizeLocalPath(path string) string {
-	// Clean input - remove leading/trailing whitespace
 	clean := strings.TrimSpace(path)
 
-	// Remove surrounding quotes (drag-drop adds these)
-	if (strings.HasPrefix(clean, `"`) && strings.HasSuffix(clean, `"`)) ||
-		(strings.HasPrefix(clean, `'`) && strings.HasSuffix(clean, `'`)) {
-		clean = clean[1 : len(clean)-1]
+	// Use a shell parser to decode quoted/escaped paths from drag-and-drop/paste.
+	if fields, err := shell.Fields(clean, nil); err == nil && len(fields) == 1 {
+		return fields[0]
 	}
 
-	// Unescape common terminal-escaped characters
-	replacements := map[string]string{
-		"\\ ": " ",
-		"\\(": "(",
-		"\\)": ")",
-		"\\[": "[",
-		"\\]": "]",
-		"\\&": "&",
-		"\\;": ";",
-		"\\'": "'",
-		"\\?": "?",
-		"\\|": "|",
-	}
-
-	for escaped, unescaped := range replacements {
-		clean = strings.ReplaceAll(clean, escaped, unescaped)
-	}
-
+	// Fallback: keep trimmed input untouched if parsing fails.
 	return clean
 }

--- a/retrieval_test.go
+++ b/retrieval_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+func TestNormalizeLocalPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "removes surrounding single quotes",
+			input: "'/tmp/hello world.html'",
+			want:  "/tmp/hello world.html",
+		},
+		{
+			name:  "unescapes common shell escaped path",
+			input: "/tmp/hello\\ world\\.html",
+			want:  "/tmp/hello world.html",
+		},
+		{
+			name:  "unescapes escaped pipe",
+			input: "/tmp/a\\|b.html",
+			want:  "/tmp/a|b.html",
+		},
+		{
+			name:  "unescapes escaped slash",
+			input: "\\/tmp\\/foo\\/bar.html",
+			want:  "/tmp/foo/bar.html",
+		},
+		{
+			name:  "returns trimmed input when shell parse fails",
+			input: "  '/tmp/unclosed  ",
+			want:  "'/tmp/unclosed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeLocalPath(tt.input)
+			if got != tt.want {
+				t.Fatalf("normalizeLocalPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- Avoid fragile manual string comparisons and ad-hoc escape handling when converting terminal-dragged/pasted file path strings into a form usable by `os.ReadFile`.
- Delegate decoding of quoted and escaped shell tokens to a purpose-built parser to match real shell behavior and reduce edge-case bugs.

### Description
- Replaced custom quote/escape stripping and the `unescapeBackslashes` helper in `normalizeLocalPath` with a single call to `mvdan.cc/sh/v3/shell.Fields` to decode the input.
- Removed manual handling for the `$'...'` zsh ANSI-C quoting and other bespoke replacement logic, and kept a minimal fallback that returns the trimmed input when parsing fails.
- Added the `mvdan.cc/sh/v3` dependency to `go.mod` and updated `go.sum` accordingly.
- Added `retrieval_test.go` containing unit tests that align with the new contract, including a malformed-input fallback case.

### Testing
- Ran `gofmt -w retrieval.go retrieval_test.go` to format changes, which completed successfully.
- Ran `go test ./...`; an earlier `go test` run failed while the test expected a `$'...'` special case, and after updating tests to the new contract the final `go test ./...` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699534d3c8908329b08a107c2d1e38cf)