### PR TITLE
Improve TUI wrapping and cap archive filenames

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.9
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/chromedp/chromedp v0.14.1
 	github.com/go-shiori/go-readability v0.0.0-20250217085726-9f5bf5ca7612
 	github.com/mattn/go-ieproxy v0.0.12
@@ -25,7 +26,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.3.2 // indirect
-	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d // indirect

--- a/postprocessing/postprocessing.go
+++ b/postprocessing/postprocessing.go
@@ -179,7 +179,9 @@ func processContent(article *readability.Article, baseURL *url.URL, excludeImage
 	return article, imageCount, nil
 }
 
-// TitleToFilename replaces problematic characters in page title to give a generally valid filename
+const maxFilenameBaseBytes = 200
+
+// TitleToFilename replaces problematic characters in page title to give a generally valid filename.
 func TitleToFilename(title string) string {
 	filename := strings.ReplaceAll(title, "/", "_")
 	filename = strings.ReplaceAll(filename, "\\", "_")
@@ -190,5 +192,22 @@ func TitleToFilename(title string) string {
 	filename = strings.ReplaceAll(filename, "<", "_")
 	filename = strings.ReplaceAll(filename, ">", "_")
 	filename = strings.ReplaceAll(filename, "|", "_")
+	filename = truncateStringBytes(filename, maxFilenameBaseBytes)
 	return filename + ".html"
+}
+
+func truncateStringBytes(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+
+	var b strings.Builder
+	for _, r := range s {
+		runeString := string(r)
+		if b.Len()+len(runeString) > maxBytes {
+			break
+		}
+		b.WriteString(runeString)
+	}
+	return b.String()
 }

--- a/postprocessing/postprocessing_test.go
+++ b/postprocessing/postprocessing_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/yfzhou0904/go-to-kindle/postprocessing_test"
 )
@@ -200,4 +201,39 @@ func TestProcessArticle_Basic(t *testing.T) {
 	}
 
 	t.Logf("Basic test passed - Title: %s, Images: %d", article.Title, imageCount)
+}
+
+func TestTitleToFilenameSanitizesAndTruncates(t *testing.T) {
+	title := strings.Repeat("a", maxFilenameBaseBytes+50)
+
+	filename := TitleToFilename(title)
+
+	if len(strings.TrimSuffix(filename, ".html")) != maxFilenameBaseBytes {
+		t.Fatalf("expected filename basename to be %d bytes, got %d", maxFilenameBaseBytes, len(strings.TrimSuffix(filename, ".html")))
+	}
+	if !strings.HasSuffix(filename, ".html") {
+		t.Fatalf("expected .html suffix, got %q", filename)
+	}
+}
+
+func TestTitleToFilenameDoesNotSplitMultibyteRunes(t *testing.T) {
+	title := strings.Repeat("你", 100)
+
+	filename := TitleToFilename(title)
+	basename := strings.TrimSuffix(filename, ".html")
+
+	if len(basename) > maxFilenameBaseBytes {
+		t.Fatalf("expected basename at most %d bytes, got %d", maxFilenameBaseBytes, len(basename))
+	}
+	if !utf8.ValidString(basename) {
+		t.Fatalf("expected valid UTF-8 basename, got %q", basename)
+	}
+}
+
+func TestTitleToFilenameReplacesProblematicCharacters(t *testing.T) {
+	filename := TitleToFilename(`a/b\c:d*e?f"g<h>i|j`)
+
+	if filename != "a_b_c_d_e_f_g_h_i_j.html" {
+		t.Fatalf("unexpected filename: %q", filename)
+	}
 }

--- a/tui.go
+++ b/tui.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	readability "github.com/go-shiori/go-readability"
 	"github.com/yfzhou0904/go-to-kindle/postprocessing"
 	"github.com/yfzhou0904/go-to-kindle/util"
@@ -41,8 +42,9 @@ type model struct {
 	excludeImages   bool
 	useChromedp     bool
 	debug           bool
-	checkboxFocused int // 0 = url input, 1 = include images, 2 = use chromedp
+	checkboxFocused int  // 0 = url input, 1 = include images, 2 = use chromedp
 	inputFromCLI    bool // true when input was supplied as a CLI arg (already shell-unescaped)
+	width           int
 }
 
 // Messages for async operations
@@ -224,6 +226,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
 		return m, cmd
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		inputWidth := max(m.contentWidth(), 20)
+		m.urlInput.Width = inputWidth
+		m.titleInput.Width = inputWidth
+		return m, nil
 	}
 
 	// Update inputs based on current screen
@@ -239,6 +248,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func (m model) contentWidth() int {
+	if m.width <= 0 {
+		return 80
+	}
+	return max(m.width-2, 20)
+}
+
+func (m model) wrapText(s string) string {
+	return ansi.Wrap(s, m.contentWidth(), " /:_")
 }
 
 func (m model) View() string {
@@ -321,8 +341,8 @@ func (m model) View() string {
 		return fmt.Sprintf(
 			"%s\n\n%s\n%s\n\n%s\n\n%s\n\n%s\n",
 			headerStyle.Render("✏️  Edit Article Title"),
-			subtleStyle.Render(fmt.Sprintf("Original: %s", m.article.Title)),
-			subtleStyle.Render(metadata),
+			subtleStyle.Render(m.wrapText(fmt.Sprintf("Original: %s", m.article.Title))),
+			subtleStyle.Render(m.wrapText(metadata)),
 			m.titleInput.View(),
 			subtleStyle.Render("Press Enter to send to Kindle • Edit title or keep as-is"),
 			subtleStyle.Render("Ctrl+C to quit"),
@@ -333,8 +353,8 @@ func (m model) View() string {
 			return fmt.Sprintf(
 				"%s\n\n%s\n\n%s\n\n%s\n",
 				errorStyle.Render("❌ Error"),
-				m.err.Error(),
-				subtleStyle.Render(fmt.Sprintf("Original URL: %s", m.urlInput.Value())),
+				errorStyle.Render(m.wrapText(m.err.Error())),
+				subtleStyle.Render(m.wrapText(fmt.Sprintf("Original URL: %s", m.urlInput.Value()))),
 				subtleStyle.Render("Press Enter to send another • Esc/Ctrl+C to quit"),
 			)
 		} else {


### PR DESCRIPTION
## Summary
- Wrap long TUI error/detail text using terminal width so paths and URLs remain visible
- Resize text inputs on terminal resize
- Cap generated archive filename basenames at 200 bytes while preserving valid UTF-8

## Tests
- go test ./...