### PR TITLE
Add clipboard Markdown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Features
 
 - **Interactive Terminal UI**: Modern Bubbletea-based interface with guided workflow
-- **Multiple Sources**: Supports web URLs (http/https), local HTML files, and Safari .webarchive files
+- **Multiple Sources**: Supports web URLs, local HTML/Markdown files, Safari .webarchive files, and Markdown from the clipboard
 - **Smart Processing**: Extracts readable content, processes images, detects language
 - **Robust Retrieval**: Optional headless browser mode for JS-heavy or blocked sites
 - **Image Support**: Optional image inclusion with automatic resizing (300px max)
@@ -34,7 +34,7 @@
 ```
 
 The tool provides an intuitive 5-step workflow:
-1. **Input & Options**: Enter URL/file path, toggle image inclusion and headless browser
+1. **Input & Options**: Enter a URL/file path or read Markdown from the clipboard
 2. **Content Retrieval**: Fetch content using direct HTTP or the headless browser with progress indicator
 3. **Content Processing**: Readability extraction, image processing, and content cleaning
 4. **Review & Edit**: Check metadata (language, word count, images) and customize title
@@ -109,7 +109,8 @@ go-to-kindle
 ```
 
 ### Input Options
-- **URL or File Path**: Web articles, local HTML files, or Safari .webarchive files
+- **URL or File Path**: Web articles, local HTML/Markdown files, or Safari `.webarchive` files
+- **Clipboard Markdown**: Copy Markdown, focus **Read Markdown from clipboard**, and press Enter
 - **Include Images**: Toggle to include resized images (300px max, base64 embedded)
 - **Use Headless Browser**: Handle JS-heavy or protected sites (slower but more reliable)
 
@@ -124,6 +125,7 @@ go-to-kindle
 - News articles from most websites
 - Blog posts and long-form content
 - Local HTML files
+- Local Markdown files and Markdown copied from LLM interfaces
 - Safari .webarchive files
 - Content in English and Chinese (with proper word counting)
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/PuerkitoBio/goquery v1.10.3
 	github.com/abadojack/whatlanggo v1.0.1
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.9
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -15,6 +16,7 @@ require (
 	github.com/mattn/go-ieproxy v0.0.12
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
+	github.com/yuin/goldmark v1.8.2
 	golang.org/x/image v0.31.0
 	golang.org/x/net v0.44.0
 	howett.net/plist v1.0.0
@@ -23,7 +25,6 @@ require (
 require (
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.3.2 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=

--- a/input.go
+++ b/input.go
@@ -9,7 +9,16 @@ import (
 
 // InputResult represents normalized input ready for processing.
 type InputResult struct {
+	Kind     InputKind
+	Source   string
 	Body     io.ReadCloser
 	BaseURL  *url.URL
 	Resolver postprocessing.ImageResolver
 }
+
+type InputKind int
+
+const (
+	InputHTML InputKind = iota
+	InputMarkdown
+)

--- a/internal/repositories/file_repository.go
+++ b/internal/repositories/file_repository.go
@@ -30,7 +30,13 @@ const htmlTemplate = `<!DOCTYPE html>
         <title>{{.Title}}</title>
         <meta name="author" content="{{.Author}}">
        <style>
-               img { display: block; margin-left: auto; margin-right: auto; }
+               body { line-height: 1.5; }
+               img { display: block; max-width: 100%; height: auto; margin-left: auto; margin-right: auto; }
+               pre { white-space: pre-wrap; overflow-wrap: anywhere; padding: 0.75em; background: #f3f3f3; }
+               code { font-family: monospace; }
+               table { width: 100%; border-collapse: collapse; }
+               th, td { border: 1px solid #999; padding: 0.35em; text-align: left; }
+               blockquote { margin-left: 0; padding-left: 1em; border-left: 3px solid #999; }
        </style>
 </head>
 <body>

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/yfzhou0904/go-to-kindle/postprocessing"
+)
+
+func TestRetrieveMarkdownFileSetsInputKind(t *testing.T) {
+	path := t.TempDir() + "/notes.md"
+	if err := os.WriteFile(path, []byte("# Notes"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	input, err := retrieveContent(context.Background(), path, false, true)
+	if err != nil {
+		t.Fatalf("retrieveContent: %v", err)
+	}
+	defer input.Body.Close()
+	if input.Kind != InputMarkdown {
+		t.Fatalf("expected Markdown input, got %v", input.Kind)
+	}
+}
+
+func TestRetrieveClipboardContent(t *testing.T) {
+	original := readClipboard
+	t.Cleanup(func() { readClipboard = original })
+	readClipboard = func() (string, error) { return "# Clipboard title\n\nShort note.", nil }
+
+	input, err := retrieveClipboardContent()
+	if err != nil {
+		t.Fatalf("retrieveClipboardContent: %v", err)
+	}
+	defer input.Body.Close()
+	if input.Kind != InputMarkdown {
+		t.Fatalf("expected Markdown input, got %v", input.Kind)
+	}
+	contents, _ := io.ReadAll(input.Body)
+	if string(contents) != "# Clipboard title\n\nShort note." {
+		t.Fatalf("unexpected clipboard contents: %q", contents)
+	}
+}
+
+func TestRetrieveClipboardContentRejectsEmptyClipboard(t *testing.T) {
+	original := readClipboard
+	t.Cleanup(func() { readClipboard = original })
+	readClipboard = func() (string, error) { return " \n", nil }
+
+	if _, err := retrieveClipboardContent(); err == nil {
+		t.Fatal("expected empty clipboard error")
+	}
+}
+
+func TestPostProcessMarkdownAllowsShortContent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	input := &InputResult{
+		Kind:     InputMarkdown,
+		Body:     io.NopCloser(strings.NewReader("# Useful answer\n\nUse `go test ./...`.")),
+		Resolver: postprocessing.NewNetworkImageResolver(nil),
+	}
+
+	article, filename, _, wordCount, imageCount, _, err := postProcessContent(context.Background(), input, false)
+	if err != nil {
+		t.Fatalf("postProcessContent: %v", err)
+	}
+	if article.Title != "Useful answer" {
+		t.Fatalf("unexpected title: %q", article.Title)
+	}
+	if filename != "Useful answer.html" {
+		t.Fatalf("unexpected filename: %q", filename)
+	}
+	if wordCount == 0 || imageCount != 0 {
+		t.Fatalf("unexpected counts: words=%d images=%d", wordCount, imageCount)
+	}
+	if !strings.Contains(article.Content, "<code>go test ./...</code>") {
+		t.Fatalf("expected rendered code, got %q", article.Content)
+	}
+}

--- a/postprocessing/markdown.go
+++ b/postprocessing/markdown.go
@@ -1,0 +1,79 @@
+package postprocessing
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	readability "github.com/go-shiori/go-readability"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/text"
+)
+
+// ProcessMarkdownWithContext renders Markdown without applying webpage readability extraction.
+func ProcessMarkdownWithContext(_ context.Context, resp *http.Response, excludeImages bool, resolver ImageResolver) (*readability.Article, string, int, error) {
+	source, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("failed to read Markdown: %w", err)
+	}
+
+	md := newMarkdownParser()
+	doc := md.Parser().Parse(text.NewReader(source))
+	title := markdownTitle(doc, source)
+
+	var rendered bytes.Buffer
+	if err := md.Renderer().Render(&rendered, source, doc); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to render Markdown: %w", err)
+	}
+
+	parsed, err := goquery.NewDocumentFromReader(bytes.NewReader(rendered.Bytes()))
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("failed to parse rendered Markdown: %w", err)
+	}
+	text := strings.TrimSpace(parsed.Text())
+	article := &readability.Article{Title: title, Content: rendered.String(), TextContent: text}
+	article, imageCount, err := processContent(article, resp.Request.URL, excludeImages, resolver, true)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("failed to post-process Markdown: %w", err)
+	}
+	return article, TitleToFilename(title), imageCount, nil
+}
+
+func newMarkdownParser() goldmark.Markdown {
+	return goldmark.New(goldmark.WithExtensions(extension.GFM))
+}
+
+func markdownTitle(doc ast.Node, source []byte) string {
+	var firstHeading string
+	var firstText string
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if heading, ok := node.(*ast.Heading); ok && heading.Level == 1 && firstHeading == "" {
+			firstHeading = strings.TrimSpace(string(heading.Text(source)))
+		}
+		if paragraph, ok := node.(*ast.Paragraph); ok && firstText == "" {
+			firstText = strings.TrimSpace(string(paragraph.Text(source)))
+		}
+		return ast.WalkContinue, nil
+	})
+	if firstHeading != "" {
+		return firstHeading
+	}
+	if firstText != "" {
+		const maxTitleRunes = 100
+		runes := []rune(firstText)
+		if len(runes) > maxTitleRunes {
+			return strings.TrimSpace(string(runes[:maxTitleRunes])) + "..."
+		}
+		return firstText
+	}
+	return "Markdown from Clipboard"
+}

--- a/postprocessing/markdown_test.go
+++ b/postprocessing/markdown_test.go
@@ -1,0 +1,45 @@
+package postprocessing
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/yuin/goldmark/text"
+)
+
+func TestProcessMarkdownRendersGFMAndPreservesLinks(t *testing.T) {
+	source := "# Reading Notes\n\n[Reference](https://example.com)\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\n```go\nfmt.Println(\"hi\")\n```"
+	resp := &http.Response{
+		Body:    io.NopCloser(strings.NewReader(source)),
+		Request: &http.Request{URL: &url.URL{}},
+	}
+
+	article, filename, images, err := ProcessMarkdownWithContext(context.Background(), resp, false, NewNetworkImageResolver(nil))
+	if err != nil {
+		t.Fatalf("ProcessMarkdownWithContext: %v", err)
+	}
+	if article.Title != "Reading Notes" || filename != "Reading Notes.html" {
+		t.Fatalf("unexpected title/filename: %q %q", article.Title, filename)
+	}
+	for _, expected := range []string{"<table>", "<pre><code class=\"language-go\">", "href=\"https://example.com\""} {
+		if !strings.Contains(article.Content, expected) {
+			t.Errorf("expected %q in rendered content", expected)
+		}
+	}
+	if images != 0 {
+		t.Fatalf("expected no images, got %d", images)
+	}
+}
+
+func TestMarkdownTitleFallsBackToFirstText(t *testing.T) {
+	source := []byte("A concise explanation without a heading.\n\nMore detail.")
+	md := newMarkdownParser()
+	doc := md.Parser().Parse(text.NewReader(source))
+	if got := markdownTitle(doc, source); got != "A concise explanation without a heading." {
+		t.Fatalf("unexpected title: %q", got)
+	}
+}

--- a/postprocessing/postprocessing.go
+++ b/postprocessing/postprocessing.go
@@ -67,7 +67,7 @@ func ProcessArticleWithContext(ctx context.Context, resp *http.Response, exclude
 	}
 
 	// Post-process the article content
-	processedArticle, imageCount, err := processContent(&article, resp.Request.URL, excludeImages, resolver)
+	processedArticle, imageCount, err := processContent(&article, resp.Request.URL, excludeImages, resolver, false)
 	if err != nil {
 		return nil, "", 0, fmt.Errorf("failed to post-process article: %v", err)
 	}
@@ -137,7 +137,7 @@ func (r *WebarchiveImageResolver) ResolveImage(src string, baseURL *url.URL) (st
 }
 
 // processContent cleans up the article content by processing images and removing unwanted elements
-func processContent(article *readability.Article, baseURL *url.URL, excludeImages bool, resolver ImageResolver) (*readability.Article, int, error) {
+func processContent(article *readability.Article, baseURL *url.URL, excludeImages bool, resolver ImageResolver, preserveLinks bool) (*readability.Article, int, error) {
 	contentDoc, err := goquery.NewDocumentFromReader(strings.NewReader(article.Content))
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to parse content: %v", err)
@@ -166,10 +166,12 @@ func processContent(article *readability.Article, baseURL *url.URL, excludeImage
 	contentDoc.Find("svg").Remove()
 
 	// Remove <a> tags but keep their contents (text, images, etc.)
-	contentDoc.Find("a").Each(func(i int, s *goquery.Selection) {
-		html, _ := s.Html()
-		s.ReplaceWithHtml(html)
-	})
+	if !preserveLinks {
+		contentDoc.Find("a").Each(func(i int, s *goquery.Selection) {
+			html, _ := s.Html()
+			s.ReplaceWithHtml(html)
+		})
+	}
 
 	article.Content, err = contentDoc.Find("body").Html()
 	if err != nil {

--- a/postprocessing/webarchive_postprocessing_test.go
+++ b/postprocessing/webarchive_postprocessing_test.go
@@ -59,7 +59,7 @@ func TestProcessContentWithWebarchiveImages(t *testing.T) {
 	}
 
 	resolver := NewWebarchiveImageResolver(resources)
-	processed, imageCount, err := processContent(&article, baseURL, false, resolver)
+	processed, imageCount, err := processContent(&article, baseURL, false, resolver, false)
 	if err != nil {
 		t.Fatalf("processContent error: %v", err)
 	}

--- a/retrieval.go
+++ b/retrieval.go
@@ -14,14 +14,35 @@ import (
 	"unicode/utf8"
 
 	"github.com/abadojack/whatlanggo"
-	"github.com/mattn/go-shellwords"
+	"github.com/atotto/clipboard"
 	readability "github.com/go-shiori/go-readability"
+	"github.com/mattn/go-shellwords"
 	"github.com/yfzhou0904/go-to-kindle/internal/repositories"
 	"github.com/yfzhou0904/go-to-kindle/internal/webarchive"
 	"github.com/yfzhou0904/go-to-kindle/postprocessing"
 	"github.com/yfzhou0904/go-to-kindle/retrieval"
 	"github.com/yfzhou0904/go-to-kindle/util"
 )
+
+var readClipboard = clipboard.ReadAll
+
+func retrieveClipboardContent() (*InputResult, error) {
+	contents, err := readClipboard()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read clipboard: %w", err)
+	}
+	if strings.TrimSpace(contents) == "" {
+		return nil, fmt.Errorf("clipboard is empty")
+	}
+
+	return &InputResult{
+		Kind:     InputMarkdown,
+		Source:   "Clipboard Markdown",
+		Body:     io.NopCloser(strings.NewReader(contents)),
+		BaseURL:  &url.URL{},
+		Resolver: postprocessing.NewNetworkImageResolver(nil),
+	}, nil
+}
 
 // retrieveContent handles both web URLs and local files, returning a normalized input result.
 func retrieveContent(ctx context.Context, input string, useChromedp bool, inputFromCLI bool) (*InputResult, error) {
@@ -49,6 +70,8 @@ func retrieveContent(ctx context.Context, input string, useChromedp bool, inputF
 		}
 
 		result = InputResult{
+			Kind:     InputHTML,
+			Source:   "Web",
 			Body:     retrievalResult.Content,
 			BaseURL:  retrievalResult.URL,
 			Resolver: postprocessing.NewNetworkImageResolver(nil),
@@ -78,6 +101,8 @@ func retrieveContent(ctx context.Context, input string, useChromedp bool, inputF
 			resolver := postprocessing.NewWebarchiveImageResolver(resources).
 				WithFallback(postprocessing.NewNetworkImageResolver(nil))
 			result = InputResult{
+				Kind:     InputHTML,
+				Source:   "Webarchive file",
 				Body:     io.NopCloser(bytes.NewReader(htmlContent)),
 				BaseURL:  baseURL,
 				Resolver: resolver,
@@ -87,8 +112,16 @@ func retrieveContent(ctx context.Context, input string, useChromedp bool, inputF
 			if err != nil {
 				return nil, fmt.Errorf("failed to open local file: %v", err)
 			}
+			kind := InputHTML
+			source := "HTML file"
+			if ext := strings.ToLower(filepath.Ext(absPath)); ext == ".md" || ext == ".markdown" {
+				kind = InputMarkdown
+				source = "Markdown file"
+			}
 			result = InputResult{
-				Body: file,
+				Kind:   kind,
+				Source: source,
+				Body:   file,
 				BaseURL: &url.URL{
 					Path: link,
 				},
@@ -128,7 +161,15 @@ func postProcessContent(ctx context.Context, input *InputResult, excludeImages b
 		},
 	}
 
-	article, filename, imageCount, err := postprocessing.ProcessArticleWithContext(ctx, resp, excludeImages, input.Resolver)
+	var article *readability.Article
+	var filename string
+	var imageCount int
+	var err error
+	if input.Kind == InputMarkdown {
+		article, filename, imageCount, err = postprocessing.ProcessMarkdownWithContext(ctx, resp, excludeImages, input.Resolver)
+	} else {
+		article, filename, imageCount, err = postprocessing.ProcessArticleWithContext(ctx, resp, excludeImages, input.Resolver)
+	}
 	if err != nil {
 		return nil, "", "", 0, 0, "", fmt.Errorf("failed to process article: %v", err)
 	}
@@ -142,11 +183,11 @@ func postProcessContent(ctx context.Context, input *InputResult, excludeImages b
 	})
 	wordCount := 0
 	if lang == whatlanggo.Cmn {
-		wordCount = utf8.RuneCountInString(article.Content)
+		wordCount = utf8.RuneCountInString(article.TextContent)
 	} else {
-		wordCount = len(strings.Fields(article.Content))
+		wordCount = len(strings.Fields(article.TextContent))
 	}
-	if wordCount < 100 {
+	if input.Kind != InputMarkdown && wordCount < 100 {
 		return nil, "", "", 0, 0, "", fmt.Errorf("article is too short (%d words)", wordCount)
 	}
 

--- a/tui.go
+++ b/tui.go
@@ -42,8 +42,9 @@ type model struct {
 	excludeImages   bool
 	useChromedp     bool
 	debug           bool
-	checkboxFocused int  // 0 = url input, 1 = include images, 2 = use chromedp
+	checkboxFocused int  // 0 = URL input, 1 = clipboard, 2 = images, 3 = browser
 	inputFromCLI    bool // true when input was supplied as a CLI arg (already shell-unescaped)
+	inputSource     string
 	width           int
 }
 
@@ -138,7 +139,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "tab", "down":
 			if m.state == inputScreen {
-				m.checkboxFocused = (m.checkboxFocused + 1) % 3
+				m.checkboxFocused = (m.checkboxFocused + 1) % 4
 				if m.checkboxFocused == 0 {
 					m.urlInput.Focus()
 				} else {
@@ -147,7 +148,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "up":
 			if m.state == inputScreen {
-				m.checkboxFocused = (m.checkboxFocused + 2) % 3
+				m.checkboxFocused = (m.checkboxFocused + 3) % 4
 				if m.checkboxFocused == 0 {
 					m.urlInput.Focus()
 				} else {
@@ -157,9 +158,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case " ":
 			if m.state == inputScreen {
 				switch m.checkboxFocused {
-				case 1:
-					m.excludeImages = !m.excludeImages
 				case 2:
+					m.excludeImages = !m.excludeImages
+				case 3:
 					m.useChromedp = !m.useChromedp
 				}
 			}
@@ -167,10 +168,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.state == completionScreen {
 				return m, tea.Quit
 			}
+			if m.state == editScreen {
+				initial := initialModel()
+				return initial, initial.spinner.Tick
+			}
 		case "enter":
 			switch m.state {
 			case inputScreen:
-				if m.urlInput.Value() != "" {
+				if m.checkboxFocused == 1 {
+					m.state = retrievalScreen
+					return m, tea.Batch(m.spinner.Tick, retrieveClipboardContentCmd())
+				}
+				if m.checkboxFocused == 0 && m.urlInput.Value() != "" {
 					m.state = retrievalScreen
 					return m, tea.Batch(m.spinner.Tick, retrieveContentCmd(m.urlInput.Value(), m.useChromedp, m.debug, m.inputFromCLI))
 
@@ -195,6 +204,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err
 			m.state = completionScreen
 		} else {
+			m.inputSource = msg.input.Source
 			m.state = postProcessingScreen
 			return m, tea.Batch(m.spinner.Tick, processContentCmd(msg.input, m.excludeImages, m.debug))
 		}
@@ -274,12 +284,15 @@ func (m model) View() string {
 			browserCheckbox = "☑"
 		}
 
+		clipboardStyle := subtleStyle
 		excludeImagesStyle := subtleStyle
 		browserStyle := subtleStyle
 		switch m.checkboxFocused {
 		case 1:
-			excludeImagesStyle = headerStyle
+			clipboardStyle = headerStyle
 		case 2:
+			excludeImagesStyle = headerStyle
+		case 3:
 			browserStyle = headerStyle
 		}
 
@@ -290,23 +303,32 @@ func (m model) View() string {
 			proxyDisplay = fmt.Sprintf("\n\n%s", subtleStyle.Render(fmt.Sprintf("🌐 Proxy detected: %s (from %s)", proxyInfo.URL, proxyInfo.Source)))
 		}
 
+		browserControl := fmt.Sprintf("\n%s %s", browserStyle.Render(browserCheckbox), browserStyle.Render("Use browser"))
+		if m.checkboxFocused == 1 {
+			browserControl = ""
+		}
+
 		return fmt.Sprintf(
-			"%s\n\n%s\n\n%s %s\n%s %s%s\n\n%s\n",
+			"%s\n\n%s\n\n%s\n\n%s %s%s%s\n\n%s\n",
 			headerStyle.Render("📚 Go to Kindle"),
 			m.urlInput.View(),
+			clipboardStyle.Render("▸ Read Markdown from clipboard"),
 			excludeImagesStyle.Render(excludeImagesCheckbox),
 			excludeImagesStyle.Render("Exclude images"),
-			browserStyle.Render(browserCheckbox),
-			browserStyle.Render("Use browser"),
+			browserControl,
 			proxyDisplay,
-			subtleStyle.Render("Press Enter to fetch • Tab/↑↓ to navigate • Space to toggle • Ctrl+C to quit"),
+			subtleStyle.Render("Enter to select • Tab/↑↓ to navigate • Space to toggle • Ctrl+C to quit"),
 		)
 
 	case retrievalScreen:
+		message := "🔍 Retrieving content..."
+		if m.checkboxFocused == 1 {
+			message = "📋 Reading Markdown from clipboard..."
+		}
 		return fmt.Sprintf(
 			"%s %s\n\n%s\n",
 			m.spinner.View(),
-			"🔍 Retrieving content...",
+			message,
 			subtleStyle.Render("Ctrl+C to quit"),
 		)
 
@@ -330,13 +352,17 @@ func (m model) View() string {
 		// Make file path clickable using OSC 8 hyperlink escape sequence
 		clickableFilePath := fmt.Sprintf("\033]8;;file://%s\033\\%s\033]8;;\033\\", m.archivePath, m.archivePath)
 
+		source := m.inputSource
+		if source == "" {
+			source = "Web / file"
+		}
 		var metadata string
 		if !m.excludeImages && m.imageCount > 0 {
-			metadata = fmt.Sprintf("Language: %s • Words: %d • Images: %d • File: %s",
-				m.language, m.wordCount, m.imageCount, clickableFilePath)
+			metadata = fmt.Sprintf("Source: %s • Language: %s • Words: %d • Images: %d • File: %s",
+				source, m.language, m.wordCount, m.imageCount, clickableFilePath)
 		} else {
-			metadata = fmt.Sprintf("Language: %s • Words: %d • File: %s",
-				m.language, m.wordCount, clickableFilePath)
+			metadata = fmt.Sprintf("Source: %s • Language: %s • Words: %d • File: %s",
+				source, m.language, m.wordCount, clickableFilePath)
 		}
 		return fmt.Sprintf(
 			"%s\n\n%s\n%s\n\n%s\n\n%s\n\n%s\n",
@@ -345,7 +371,7 @@ func (m model) View() string {
 			subtleStyle.Render(m.wrapText(metadata)),
 			m.titleInput.View(),
 			subtleStyle.Render("Press Enter to send to Kindle • Edit title or keep as-is"),
-			subtleStyle.Render("Ctrl+C to quit"),
+			subtleStyle.Render("Esc to go back • Ctrl+C to quit"),
 		)
 
 	case completionScreen:
@@ -378,6 +404,13 @@ func retrieveContentCmd(input string, useChromedp bool, debug bool, inputFromCLI
 			ctx = util.WithDebug(ctx, debug)
 		}
 		result, err := retrieveContent(ctx, input, useChromedp, inputFromCLI)
+		return retrievalCompleteMsg{input: result, err: err}
+	}
+}
+
+func retrieveClipboardContentCmd() tea.Cmd {
+	return func() tea.Msg {
+		result, err := retrieveClipboardContent()
 		return retrievalCompleteMsg{input: result, err: err}
 	}
 }

--- a/tui.go
+++ b/tui.go
@@ -169,8 +169,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 			if m.state == editScreen {
-				initial := initialModel()
-				return initial, initial.spinner.Tick
+				m.state = inputScreen
+				m.article = nil
+				m.filename = ""
+				m.archivePath = ""
+				m.language = ""
+				m.wordCount = 0
+				m.imageCount = 0
+				m.inputSource = ""
+				m.err = nil
+				m.titleInput.Blur()
+				if m.checkboxFocused == 0 {
+					m.urlInput.Focus()
+				}
+				return m, nil
 			}
 		case "enter":
 			switch m.state {
@@ -179,7 +191,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.state = retrievalScreen
 					return m, tea.Batch(m.spinner.Tick, retrieveClipboardContentCmd())
 				}
-				if m.checkboxFocused == 0 && m.urlInput.Value() != "" {
+				if m.urlInput.Value() != "" {
 					m.state = retrievalScreen
 					return m, tea.Batch(m.spinner.Tick, retrieveContentCmd(m.urlInput.Value(), m.useChromedp, m.debug, m.inputFromCLI))
 

--- a/tui_test.go
+++ b/tui_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestInputViewKeepsClipboardActionMinimalAndContextual(t *testing.T) {
+	m := initialModel()
+	m.checkboxFocused = 1
+	view := m.View()
+
+	if !strings.Contains(view, "Read Markdown from clipboard") {
+		t.Fatal("expected clipboard action")
+	}
+	if strings.Contains(view, "Use browser") {
+		t.Fatal("browser option should be hidden while clipboard action is focused")
+	}
+	if strings.Contains(view, "Markdown mode") || strings.Contains(view, "Markdown editor") {
+		t.Fatal("unexpected extra Markdown controls")
+	}
+}
+
+func TestInputNavigationIncludesClipboardAction(t *testing.T) {
+	m := initialModel()
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	got := updated.(model)
+	if got.checkboxFocused != 1 {
+		t.Fatalf("expected clipboard action focused after Tab, got %d", got.checkboxFocused)
+	}
+}

--- a/tui_test.go
+++ b/tui_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -29,5 +30,51 @@ func TestInputNavigationIncludesClipboardAction(t *testing.T) {
 	got := updated.(model)
 	if got.checkboxFocused != 1 {
 		t.Fatalf("expected clipboard action focused after Tab, got %d", got.checkboxFocused)
+	}
+}
+
+func TestEnterSubmitsURLFromOptionRows(t *testing.T) {
+	for _, focus := range []int{0, 2, 3} {
+		t.Run(fmt.Sprintf("focus_%d", focus), func(t *testing.T) {
+			m := initialModel(WithURL("https://example.com/article"))
+			m.checkboxFocused = focus
+
+			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			got := updated.(model)
+			if got.state != retrievalScreen || cmd == nil {
+				t.Fatalf("expected URL retrieval from focus %d", focus)
+			}
+		})
+	}
+}
+
+func TestEscFromEditPreservesInputConfiguration(t *testing.T) {
+	m := initialModel(
+		WithURL("/tmp/quoted path/article.html"),
+		WithDebugFlag(true),
+	)
+	m.state = editScreen
+	m.checkboxFocused = 3
+	m.excludeImages = true
+	m.useChromedp = true
+	m.inputSource = "Web"
+	m.filename = "article.html"
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	got := updated.(model)
+	if cmd != nil {
+		t.Fatal("expected no command when returning to input")
+	}
+	if got.state != inputScreen {
+		t.Fatalf("expected input screen, got %v", got.state)
+	}
+	if got.urlInput.Value() != "/tmp/quoted path/article.html" || !got.inputFromCLI || !got.debug {
+		t.Fatal("CLI input state was not preserved")
+	}
+	if !got.excludeImages || !got.useChromedp || got.checkboxFocused != 3 {
+		t.Fatal("input controls were not preserved")
+	}
+	if got.filename != "" || got.inputSource != "" {
+		t.Fatal("processed document state was not cleared")
 	}
 }


### PR DESCRIPTION
## Summary

- add a minimal **Read Markdown from clipboard** action to the existing TUI
- render clipboard and local Markdown files with GitHub-flavored Markdown while preserving links and images
- infer document titles, allow short Markdown notes, and show the source during review
- improve Kindle HTML styling for code blocks, tables, blockquotes, and responsive images
- document the workflow and add retrieval, rendering, and TUI regression coverage

## Why

LLM responses are often available as copied Markdown rather than webpages. This lets those responses use the existing title review, archive, and Kindle email delivery flow without passing structured Markdown through webpage readability extraction.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feature-focused changes with tests; existing HTML/webarchive paths keep prior link-stripping and length checks.
> 
> **Overview**
> Adds **Markdown as a first-class input** alongside URLs and HTML: local `.md`/`.markdown` files, plus a TUI **Read Markdown from clipboard** action (goldmark GFM rendering, title inference, links preserved via `preserveLinks` in post-processing).
> 
> **Retrieval and processing** tag inputs with `InputKind`/`Source`, route Markdown through `ProcessMarkdownWithContext` instead of readability, skip the 100-word minimum for Markdown, and count words from `TextContent`. **TUI** gains a fourth focus target, clipboard Enter flow, source on the edit screen, Esc back from edit, and hides the browser toggle when clipboard is focused. **Kindle HTML** template picks up styling for code, tables, blockquotes, and responsive images. README and tests cover the new paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 855e622b623d077350fa59f00057ce75454a1feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->