### PR TITLE
Add article date context

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - **Robust Retrieval**: Optional headless browser mode for JS-heavy or blocked sites
 - **Image Support**: Optional image inclusion with automatic resizing (300px max)
 - **Editable Titles**: Review and customize article titles before sending
+- **Date Context**: Optionally prepend published, updated, and sent dates to the Kindle article
 - **Kindle Optimized**: Generates clean HTML files perfect for Kindle reading
 - **Email Delivery**: Automatic SMTP delivery to your Kindle email address
 
@@ -37,7 +38,7 @@ The tool provides an intuitive workflow:
 1. **Input & Options**: Enter a URL/file path or read Markdown from the clipboard
 2. **Content Retrieval**: Fetch content using direct HTTP or the headless browser with progress indicator
 3. **Content Processing**: Readability extraction, image processing, and content cleaning
-4. **Review & Edit**: Check metadata (language, word count, images) and customize title
+4. **Review & Edit**: Check metadata, customize the title, and choose whether to add date context
 5. **Delivery**: Email to Kindle with local archive copy
 
 ## Requirements
@@ -120,6 +121,7 @@ go-to-kindle
 - **Image Processing**: Downloads, resizes, and embeds images as base64 data URLs
 - **Language Detection**: Supports English and Chinese with appropriate word counting
 - **Content Cleaning**: Removes ads, navigation, and irrelevant elements
+- **Date Context**: Adds declared publication/update dates and the send date in `YYYY/M/D` format; enabled by default on the review screen
 
 ### Supported Content
 - News articles from most websites
@@ -133,7 +135,7 @@ go-to-kindle
 - **Enter**: Proceed to next step
 - **Ctrl+C**: Quit at any time
 - **Tab/↑↓**: Navigate between input fields and options
-- **Space**: Toggle checkboxes (Include Images, Use Headless Browser)
+- **Space**: Toggle the focused checkbox, including date context on the review screen
 
 ## Development
 
@@ -152,4 +154,4 @@ Contributor setup and conventions are documented in
 
 ## File Storage
 
-Processed articles are saved to `~/.go-to-kindle/archive/` as HTML files for your records.
+Processed articles are saved to `~/.go-to-kindle/archive/` as HTML files for your records. After a successful send, the archive matches the delivered article, including its optional date context line.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ URL, file, webarchive, or clipboard
    Parse, clean, and embed images
               |
               v
-       Review article title
+       Review title and dates
               |
               v
         Archive and email
@@ -59,4 +59,3 @@ The final artifact is a `readability.Article`; storage and delivery do not need
 to know which input produced it.
 
 See the [documentation index](README.md) for each module's detailed behavior.
-

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -12,7 +12,12 @@ path. If the title changed, it writes the article under the new name and removes
 the old archive file. Otherwise it refreshes the existing file.
 
 Archive HTML includes the article title and Kindle-oriented styling around the
-processed content. Files remain in the archive after successful delivery.
+processed content. When enabled on the review screen, final rendering prepends
+available published and updated dates plus the sent date in `YYYY/M/D` format.
+The initial pre-review archive has no date line; a successful send rewrites it
+to match the delivered attachment. An SMTP failure removes the unconfirmed
+sent date from the archive. Files remain in the archive after successful
+delivery.
 
 ## Email
 

--- a/docs/processing.md
+++ b/docs/processing.md
@@ -7,7 +7,8 @@ content cleanup, image handling, filename generation, and output storage.
 ## HTML
 
 `ProcessArticleWithContext` uses go-readability to extract the article title,
-text, and main HTML. Ordinary web links are removed from the final content.
+text, main HTML, and declared publication and modification times. Ordinary web
+links are removed from the final content.
 Articles with fewer than 100 detected words are rejected by orchestration as a
 likely extraction failure.
 
@@ -35,4 +36,3 @@ filename from the title. Filename truncation respects UTF-8 boundaries.
 The HTML wrapper and Kindle-oriented CSS live in
 `internal/repositories/file_repository.go`. See [delivery.md](delivery.md) for
 how the generated artifact is archived and sent.
-

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -11,7 +11,8 @@ the interface can show progress without blocking updates.
 2. **Retrieval** waits for the selected source to be loaded.
 3. **Post-processing** extracts and prepares the article.
 4. **Edit** shows source, language, word count, and image count while allowing
-   the title to be changed.
+   the title to be changed. A default-on checkbox previews and controls the
+   published, updated, and sent date line.
 5. **Sending** archives the final title and emails the attachment.
 6. **Completion** reports success or an error.
 
@@ -21,8 +22,9 @@ screen.
 
 ## Navigation
 
-Tab and arrow keys move among input controls, Space toggles binary options, and
-Enter activates the clipboard action or submits a non-empty URL/file value.
+Tab and arrow keys move among controls, Space toggles binary options, and Enter
+activates the clipboard action, submits a non-empty URL/file value, or sends
+from the review screen.
 Escape from the edit screen returns to the existing input configuration rather
 than creating a fresh model. `Ctrl+C` exits from any screen.
 
@@ -32,8 +34,9 @@ than creating a fresh model. `Ctrl+C` exits from any screen.
 - Browser configuration is hidden when it does not apply to clipboard input.
 - Changing the title updates both the article metadata and eventual archive
   filename.
+- Date context is enabled for each new article and may be disabled per send.
+- The sent timestamp is captured once when the review screen is submitted.
 - Terminal width controls wrapping but does not change workflow state.
 
 See [architecture.md](architecture.md) for module boundaries and
 [delivery.md](delivery.md) for the final command.
-

--- a/internal/repositories/file_repository.go
+++ b/internal/repositories/file_repository.go
@@ -3,13 +3,16 @@ package repositories
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
+	"time"
 
 	readability "github.com/go-shiori/go-readability"
 )
 
 type FileRepository interface {
 	SaveArticle(article *readability.Article, path string) error
+	SaveArticleWithDates(article *readability.Article, path string, sentTime time.Time) error
 }
 
 type localFileRepository struct{}
@@ -19,9 +22,10 @@ func NewLocalFileRepository() FileRepository {
 }
 
 type htmlData struct {
-	Title   string
-	Content string
-	Author  string
+	Title       string
+	Content     string
+	Author      string
+	DateContext string
 }
 
 const htmlTemplate = `<!DOCTYPE html>
@@ -37,15 +41,25 @@ const htmlTemplate = `<!DOCTYPE html>
                table { width: 100%; border-collapse: collapse; }
                th, td { border: 1px solid #999; padding: 0.35em; text-align: left; }
                blockquote { margin-left: 0; padding-left: 1em; border-left: 3px solid #999; }
+               .article-dates { color: #666; font-size: 0.9em; margin: 0 0 0.75em; }
        </style>
 </head>
 <body>
+        {{if .DateContext}}<p class="article-dates">{{.DateContext}}</p>{{end}}
         {{.Content}}
 </body>
 </html>
 `
 
 func (r *localFileRepository) SaveArticle(article *readability.Article, path string) error {
+	return r.saveArticle(article, path, "")
+}
+
+func (r *localFileRepository) SaveArticleWithDates(article *readability.Article, path string, sentTime time.Time) error {
+	return r.saveArticle(article, path, FormatDateContext(article, sentTime))
+}
+
+func (r *localFileRepository) saveArticle(article *readability.Article, path string, dateContext string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0770); err != nil {
 		return err
 	}
@@ -58,9 +72,24 @@ func (r *localFileRepository) SaveArticle(article *readability.Article, path str
 
 	t := template.Must(template.New("html").Parse(htmlTemplate))
 	data := htmlData{
-		Title:   article.Title,
-		Author:  article.Byline,
-		Content: article.Content,
+		Title:       article.Title,
+		Author:      article.Byline,
+		Content:     article.Content,
+		DateContext: dateContext,
 	}
 	return t.Execute(file, data)
+}
+
+// FormatDateContext returns the date line shown in the review screen and final article.
+func FormatDateContext(article *readability.Article, sentTime time.Time) string {
+	const dateFormat = "2006/1/2"
+	parts := make([]string, 0, 3)
+	if article.PublishedTime != nil {
+		parts = append(parts, "Published "+article.PublishedTime.Format(dateFormat))
+	}
+	if article.ModifiedTime != nil && (article.PublishedTime == nil || article.ModifiedTime.Format(dateFormat) != article.PublishedTime.Format(dateFormat)) {
+		parts = append(parts, "Updated "+article.ModifiedTime.Format(dateFormat))
+	}
+	parts = append(parts, "Sent "+sentTime.Format(dateFormat))
+	return strings.Join(parts, " · ")
 }

--- a/internal/repositories/file_repository_test.go
+++ b/internal/repositories/file_repository_test.go
@@ -1,0 +1,67 @@
+package repositories
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	readability "github.com/go-shiori/go-readability"
+)
+
+func TestSaveArticleWithDates(t *testing.T) {
+	published := time.Date(2020, time.January, 2, 12, 0, 0, 0, time.UTC)
+	modified := time.Date(2021, time.November, 9, 12, 0, 0, 0, time.UTC)
+	article := &readability.Article{
+		Title:         "Dated article",
+		Content:       "<p>Article body</p>",
+		PublishedTime: &published,
+		ModifiedTime:  &modified,
+	}
+	path := filepath.Join(t.TempDir(), "article.html")
+
+	err := NewLocalFileRepository().SaveArticleWithDates(article, path, time.Date(2026, time.July, 14, 8, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("SaveArticleWithDates error: %v", err)
+	}
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read article: %v", err)
+	}
+	html := string(contents)
+	want := "Published 2020/1/2 · Updated 2021/11/9 · Sent 2026/7/14"
+	if !strings.Contains(html, `<p class="article-dates">`+want+`</p>`) {
+		t.Fatalf("expected date context %q in HTML:\n%s", want, html)
+	}
+	if strings.Index(html, want) > strings.Index(html, "Article body") {
+		t.Fatal("date context should precede the article content")
+	}
+}
+
+func TestFormatDateContextOmitsSameDayUpdate(t *testing.T) {
+	published := time.Date(2026, time.July, 14, 1, 0, 0, 0, time.UTC)
+	modified := time.Date(2026, time.July, 14, 22, 0, 0, 0, time.UTC)
+	article := &readability.Article{PublishedTime: &published, ModifiedTime: &modified}
+
+	got := FormatDateContext(article, time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC))
+	if got != "Published 2026/7/14 · Sent 2026/7/15" {
+		t.Fatalf("unexpected date context: %q", got)
+	}
+}
+
+func TestSaveArticleWithoutDates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "article.html")
+	article := &readability.Article{Title: "Plain article", Content: "<p>Body</p>"}
+	if err := NewLocalFileRepository().SaveArticle(article, path); err != nil {
+		t.Fatalf("SaveArticle error: %v", err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read article: %v", err)
+	}
+	if strings.Contains(string(contents), "article-dates") && strings.Contains(string(contents), "Sent ") {
+		t.Fatal("plain article should not contain a date line")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/yfzhou0904/go-to-kindle/internal/repositories"
 	"github.com/yfzhou0904/go-to-kindle/mail"
@@ -29,6 +30,8 @@ var Conf Config = Config{
 		ChromePath: "",
 	},
 }
+
+var sendEmailWithAttachment = mail.SendEmailWithAttachment
 
 func main() {
 	// Parse command line arguments
@@ -68,14 +71,14 @@ func main() {
 }
 
 // Process and send article
-func processAndSend(article *readability.Article, filename string, archivePath string) error {
+func processAndSend(article *readability.Article, filename string, archivePath string, includeDateContext bool, sentTime time.Time) error {
 	repo := repositories.NewLocalFileRepository()
 
 	// Check if we need to update the file with a new title
 	currentArchivePath := filepath.Join(util.BaseDir(), "archive", filename)
 	if currentArchivePath != archivePath {
 		// Title was changed, need to rewrite the file with new filename
-		if err := repo.SaveArticle(article, currentArchivePath); err != nil {
+		if err := saveFinalArticle(repo, article, currentArchivePath, includeDateContext, sentTime); err != nil {
 			return fmt.Errorf("failed to write to new archive file: %v", err)
 		}
 
@@ -87,14 +90,26 @@ func processAndSend(article *readability.Article, filename string, archivePath s
 		archivePath = currentArchivePath
 	} else {
 		// Title unchanged, but we might need to update content if title was edited
-		if err := repo.SaveArticle(article, archivePath); err != nil {
+		if err := saveFinalArticle(repo, article, archivePath, includeDateContext, sentTime); err != nil {
 			return fmt.Errorf("failed to update archive file: %v", err)
 		}
 	}
 
-	if err := mail.SendEmailWithAttachment(Conf.Email.SMTPServer, Conf.Email.From, Conf.Email.Password, Conf.Email.To, strings.TrimSuffix(filename, ".html"), archivePath, Conf.Email.Port); err != nil {
+	if err := sendEmailWithAttachment(Conf.Email.SMTPServer, Conf.Email.From, Conf.Email.Password, Conf.Email.To, strings.TrimSuffix(filename, ".html"), archivePath, Conf.Email.Port); err != nil {
+		if includeDateContext {
+			if restoreErr := repo.SaveArticle(article, archivePath); restoreErr != nil {
+				return fmt.Errorf("failed to send email: %v; failed to remove unsent date context from archive: %v", err, restoreErr)
+			}
+		}
 		return fmt.Errorf("failed to send email: %v", err)
 	}
 
 	return nil
+}
+
+func saveFinalArticle(repo repositories.FileRepository, article *readability.Article, path string, includeDateContext bool, sentTime time.Time) error {
+	if includeDateContext {
+		return repo.SaveArticleWithDates(article, path, sentTime)
+	}
+	return repo.SaveArticle(article, path)
 }

--- a/main_send_test.go
+++ b/main_send_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	readability "github.com/go-shiori/go-readability"
+	"github.com/yfzhou0904/go-to-kindle/internal/repositories"
+	"github.com/yfzhou0904/go-to-kindle/util"
+)
+
+func TestProcessAndSendPersistsDateContextOnSuccess(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	article := &readability.Article{Title: "Article", Content: "<p>Body</p>"}
+	archivePath := filepath.Join(util.BaseDir(), "archive", "Article.html")
+	if err := repositories.NewLocalFileRepository().SaveArticle(article, archivePath); err != nil {
+		t.Fatalf("create initial archive: %v", err)
+	}
+
+	originalSend := sendEmailWithAttachment
+	t.Cleanup(func() { sendEmailWithAttachment = originalSend })
+	sendEmailWithAttachment = func(_, _, _, _, _, path string, _ int) error {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(string(contents), "Sent 2026/7/14") {
+			return errors.New("attachment lacks date context")
+		}
+		return nil
+	}
+
+	if err := processAndSend(article, "Article.html", archivePath, true, time.Date(2026, time.July, 14, 8, 0, 0, 0, time.Local)); err != nil {
+		t.Fatalf("processAndSend error: %v", err)
+	}
+	contents, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read final archive: %v", err)
+	}
+	if !strings.Contains(string(contents), "Sent 2026/7/14") {
+		t.Fatal("successful archive should retain date context")
+	}
+}
+
+func TestProcessAndSendRemovesSentDateOnFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	article := &readability.Article{Title: "Article", Content: "<p>Body</p>"}
+	archivePath := filepath.Join(util.BaseDir(), "archive", "Article.html")
+	if err := repositories.NewLocalFileRepository().SaveArticle(article, archivePath); err != nil {
+		t.Fatalf("create initial archive: %v", err)
+	}
+
+	originalSend := sendEmailWithAttachment
+	t.Cleanup(func() { sendEmailWithAttachment = originalSend })
+	sendEmailWithAttachment = func(_, _, _, _, _, _ string, _ int) error { return errors.New("smtp failed") }
+
+	err := processAndSend(article, "Article.html", archivePath, true, time.Date(2026, time.July, 14, 8, 0, 0, 0, time.Local))
+	if err == nil || !strings.Contains(err.Error(), "smtp failed") {
+		t.Fatalf("expected SMTP failure, got %v", err)
+	}
+	contents, readErr := os.ReadFile(archivePath)
+	if readErr != nil {
+		t.Fatalf("read restored archive: %v", readErr)
+	}
+	if strings.Contains(string(contents), "Sent 2026/7/14") {
+		t.Fatal("failed send archive should not claim it was sent")
+	}
+}

--- a/tui.go
+++ b/tui.go
@@ -248,6 +248,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.wordCount = msg.wordCount
 			m.imageCount = msg.imageCount
 			m.titleInput.SetValue(msg.article.Title)
+			m.includeDates = true
 			m.editFocused = 0
 			m.titleInput.Focus()
 			m.state = editScreen

--- a/tui.go
+++ b/tui.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -10,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	readability "github.com/go-shiori/go-readability"
+	"github.com/yfzhou0904/go-to-kindle/internal/repositories"
 	"github.com/yfzhou0904/go-to-kindle/postprocessing"
 	"github.com/yfzhou0904/go-to-kindle/util"
 )
@@ -45,6 +47,8 @@ type model struct {
 	checkboxFocused int  // 0 = URL input, 1 = clipboard, 2 = images, 3 = browser
 	inputFromCLI    bool // true when input was supplied as a CLI arg (already shell-unescaped)
 	inputSource     string
+	includeDates    bool
+	editFocused     int // 0 = title, 1 = date context
 	width           int
 }
 
@@ -117,6 +121,7 @@ func initialModel(opts ...ModelOption) model {
 		titleInput:    titleInput,
 		spinner:       s,
 		excludeImages: false,
+		includeDates:  true,
 	}
 
 	// Apply options
@@ -145,6 +150,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					m.urlInput.Blur()
 				}
+			} else if m.state == editScreen {
+				m.editFocused = (m.editFocused + 1) % 2
+				m.updateEditFocus()
 			}
 		case "up":
 			if m.state == inputScreen {
@@ -154,6 +162,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					m.urlInput.Blur()
 				}
+			} else if m.state == editScreen {
+				m.editFocused = (m.editFocused + 1) % 2
+				m.updateEditFocus()
 			}
 		case " ":
 			if m.state == inputScreen {
@@ -163,6 +174,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case 3:
 					m.useChromedp = !m.useChromedp
 				}
+			} else if m.state == editScreen && m.editFocused == 1 {
+				m.includeDates = !m.includeDates
 			}
 		case "esc":
 			if m.state == completionScreen {
@@ -203,7 +216,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.filename = postprocessing.TitleToFilename(m.titleInput.Value())
 				}
 				m.state = sendingScreen
-				return m, tea.Batch(m.spinner.Tick, sendArticle(m.article, m.filename, m.archivePath))
+				sentTime := time.Now()
+				return m, tea.Batch(m.spinner.Tick, sendArticle(m.article, m.filename, m.archivePath, m.includeDates, sentTime))
 			case completionScreen:
 				// Reset to initial state and return to input screen
 				initial := initialModel()
@@ -234,6 +248,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.wordCount = msg.wordCount
 			m.imageCount = msg.imageCount
 			m.titleInput.SetValue(msg.article.Title)
+			m.editFocused = 0
 			m.titleInput.Focus()
 			m.state = editScreen
 		}
@@ -281,6 +296,14 @@ func (m model) contentWidth() int {
 
 func (m model) wrapText(s string) string {
 	return ansi.Wrap(s, m.contentWidth(), " /:_")
+}
+
+func (m *model) updateEditFocus() {
+	if m.editFocused == 0 {
+		m.titleInput.Focus()
+	} else {
+		m.titleInput.Blur()
+	}
 }
 
 func (m model) View() string {
@@ -376,13 +399,28 @@ func (m model) View() string {
 			metadata = fmt.Sprintf("Source: %s • Language: %s • Words: %d • File: %s",
 				source, m.language, m.wordCount, clickableFilePath)
 		}
+		dateCheckbox := "☐"
+		if m.includeDates {
+			dateCheckbox = "☑"
+		}
+		dateStyle := subtleStyle
+		if m.editFocused == 1 {
+			dateStyle = headerStyle
+		}
+		datePreview := ""
+		if m.includeDates {
+			datePreview = "\n" + subtleStyle.Render(m.wrapText(repositories.FormatDateContext(m.article, time.Now())))
+		}
 		return fmt.Sprintf(
-			"%s\n\n%s\n%s\n\n%s\n\n%s\n\n%s\n",
+			"%s\n\n%s\n%s\n\n%s\n\n%s %s%s\n\n%s\n\n%s\n",
 			headerStyle.Render("✏️  Edit Article Title"),
 			subtleStyle.Render(m.wrapText(fmt.Sprintf("Original: %s", m.article.Title))),
 			subtleStyle.Render(m.wrapText(metadata)),
 			m.titleInput.View(),
-			subtleStyle.Render("Press Enter to send to Kindle • Edit title or keep as-is"),
+			dateStyle.Render(dateCheckbox),
+			dateStyle.Render("Add date context to article"),
+			datePreview,
+			subtleStyle.Render("Press Enter to send to Kindle • Tab/↑↓ to navigate • Space to toggle"),
 			subtleStyle.Render("Esc to go back • Ctrl+C to quit"),
 		)
 
@@ -440,9 +478,9 @@ func processContentCmd(input *InputResult, excludeImages bool, debug bool) tea.C
 }
 
 // Command to send article
-func sendArticle(article *readability.Article, filename string, archivePath string) tea.Cmd {
+func sendArticle(article *readability.Article, filename string, archivePath string, includeDateContext bool, sentTime time.Time) tea.Cmd {
 	return func() tea.Msg {
-		err := processAndSend(article, filename, archivePath)
+		err := processAndSend(article, filename, archivePath, includeDateContext, sentTime)
 		return sendCompleteMsg{err: err}
 	}
 }

--- a/tui_test.go
+++ b/tui_test.go
@@ -48,6 +48,28 @@ func TestEditScreenDateContextDefaultsOnAndCanBeToggled(t *testing.T) {
 	}
 }
 
+func TestNewlyProcessedArticleResetsDateContextToOn(t *testing.T) {
+	m := initialModel()
+	m.state = editScreen
+	m.article = &readability.Article{Title: "Previous article"}
+	m.includeDates = false
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(model)
+	if m.state != inputScreen || m.includeDates {
+		t.Fatal("returning to input should preserve the previous review choice until another article is processed")
+	}
+
+	updated, _ = m.Update(postProcessingCompleteMsg{
+		article:  &readability.Article{Title: "New article"},
+		filename: "New article.html",
+	})
+	got := updated.(model)
+	if got.state != editScreen || !got.includeDates {
+		t.Fatal("date context should default on for each newly processed article")
+	}
+}
+
 func TestInputNavigationIncludesClipboardAction(t *testing.T) {
 	m := initialModel()
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})

--- a/tui_test.go
+++ b/tui_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	readability "github.com/go-shiori/go-readability"
 )
 
 func TestInputViewKeepsClipboardActionMinimalAndContextual(t *testing.T) {
@@ -21,6 +23,28 @@ func TestInputViewKeepsClipboardActionMinimalAndContextual(t *testing.T) {
 	}
 	if strings.Contains(view, "Markdown mode") || strings.Contains(view, "Markdown editor") {
 		t.Fatal("unexpected extra Markdown controls")
+	}
+}
+
+func TestEditScreenDateContextDefaultsOnAndCanBeToggled(t *testing.T) {
+	published := time.Date(2020, time.January, 2, 0, 0, 0, 0, time.UTC)
+	m := initialModel()
+	m.state = editScreen
+	m.article = &readability.Article{Title: "Article", PublishedTime: &published}
+	m.titleInput.SetValue("Article")
+
+	if !m.includeDates || !strings.Contains(m.View(), "☑") || !strings.Contains(m.View(), "Published 2020/1/2") {
+		t.Fatal("date context should default on with a preview")
+	}
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	got := updated.(model)
+	if got.editFocused != 1 {
+		t.Fatal("Tab should focus the date checkbox")
+	}
+	updated, _ = got.Update(tea.KeyMsg{Type: tea.KeySpace})
+	got = updated.(model)
+	if got.includeDates || strings.Contains(got.View(), "Published 2020/1/2") {
+		t.Fatal("Space should disable date context and hide its preview")
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a default-on date context option to the final review screen
- render declared published/updated dates and the captured sent date as YYYY/M/D
- persist the date line in the successfully sent archive and remove an unconfirmed sent date after SMTP failure
- document the workflow and add renderer, delivery lifecycle, and TUI tests

## Verification

- make test
- make build
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing delivery and archive HTML only; SMTP failure rollback is additive and covered by tests, with no auth or data-model changes.
> 
> **Overview**
> Adds an optional **date context** line to Kindle articles: published/updated dates from readability metadata plus a **Sent** date captured when the user confirms send, formatted as `YYYY/M/D` and joined with ` · `.
> 
> The **review screen** gets a default-on checkbox with live preview, Tab/Space navigation between title and the option, and `includeDates` resets to on for each newly processed article. **HTML archiving** prepends the line via `SaveArticleWithDates` / `FormatDateContext` (same-day updates are omitted). **Send flow** writes the dated HTML before SMTP; on failure it reverts the archive to undated HTML so an unconfirmed "Sent" date is not kept. SMTP is injectable in tests via `sendEmailWithAttachment`.
> 
> Docs and tests cover the workflow, renderer, delivery lifecycle, and TUI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81e69e51a0ba75621fe5696e702be0d7f5a80b80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->