### PR TITLE
Auto-prune archive files past a retention period

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ Optionally configure a custom Chrome/Chromium binary:
 chrome_path = "/usr/bin/chromium"
 ```
 
+Optionally control how long archived articles are kept:
+
+```toml
+[archive]
+retention_days = 365 # delete archived articles older than this; 0 keeps them forever
+```
+
 ### Gmail Setup
 1. Enable 2FA on your Google account
 2. Generate an App Password for go-to-kindle
@@ -155,3 +162,5 @@ Contributor setup and conventions are documented in
 ## File Storage
 
 Processed articles are saved to `~/.go-to-kindle/archive/` as HTML files for your records. After a successful send, the archive matches the delivered article, including its optional date context line.
+
+Archived files older than `archive.retention_days` (default 365) are pruned automatically at startup, at most once per day. Set `retention_days = 0` to keep files permanently.

--- a/cleanup.go
+++ b/cleanup.go
@@ -30,7 +30,10 @@ func maybeCleanupArchive(retentionDays int) {
 
 	removed, err := cleanupArchive(filepath.Join(util.BaseDir(), "archive"), retentionDays, time.Now())
 	if err != nil {
+		// Leave the marker untouched so the sweep is retried on the next
+		// startup rather than suppressed for a full day.
 		log.Printf("archive cleanup: %v", err)
+		return
 	}
 	if removed > 0 {
 		log.Printf("archive cleanup: removed %d file(s) older than %d day(s)", removed, retentionDays)

--- a/cleanup.go
+++ b/cleanup.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/yfzhou0904/go-to-kindle/util"
+)
+
+// cleanupThrottle is the minimum interval between archive cleanup sweeps.
+const cleanupThrottle = 24 * time.Hour
+
+// maybeCleanupArchive removes archive files older than the configured
+// retention period. It is best-effort and throttled to run at most once per
+// day, so it is safe to call on every startup. A retention of 0 disables
+// cleanup entirely.
+func maybeCleanupArchive(retentionDays int) {
+	if retentionDays <= 0 {
+		return
+	}
+
+	marker := filepath.Join(util.BaseDir(), "last_cleanup")
+	if info, err := os.Stat(marker); err == nil {
+		if time.Since(info.ModTime()) < cleanupThrottle {
+			return
+		}
+	}
+
+	removed, err := cleanupArchive(filepath.Join(util.BaseDir(), "archive"), retentionDays, time.Now())
+	if err != nil {
+		log.Printf("archive cleanup: %v", err)
+	}
+	if removed > 0 {
+		log.Printf("archive cleanup: removed %d file(s) older than %d day(s)", removed, retentionDays)
+	}
+
+	touchMarker(marker)
+}
+
+// cleanupArchive deletes regular files directly under dir whose modification
+// time is older than retentionDays before now. It returns the number of files
+// removed. A missing directory is not an error.
+func cleanupArchive(dir string, retentionDays int, now time.Time) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	cutoff := now.Add(-time.Duration(retentionDays) * 24 * time.Hour)
+	removed := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			if err := os.Remove(filepath.Join(dir, entry.Name())); err == nil {
+				removed++
+			}
+		}
+	}
+	return removed, nil
+}
+
+// touchMarker records the time of the most recent cleanup sweep.
+func touchMarker(path string) {
+	now := time.Now()
+	if err := os.Chtimes(path, now, now); err == nil {
+		return
+	}
+	if f, err := os.Create(path); err == nil {
+		f.Close()
+	}
+}

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeFileWithAge(t *testing.T, path string, age time.Duration) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Now().Add(-age)
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCleanupArchiveRemovesOldKeepsNew(t *testing.T) {
+	dir := t.TempDir()
+	oldFile := filepath.Join(dir, "old.html")
+	newFile := filepath.Join(dir, "new.html")
+	writeFileWithAge(t, oldFile, 400*24*time.Hour)
+	writeFileWithAge(t, newFile, 10*24*time.Hour)
+
+	removed, err := cleanupArchive(dir, 365, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 1 {
+		t.Fatalf("expected 1 removed, got %d", removed)
+	}
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Errorf("old file should have been removed")
+	}
+	if _, err := os.Stat(newFile); err != nil {
+		t.Errorf("new file should have been kept: %v", err)
+	}
+}
+
+func TestCleanupArchiveSkipsSubdirs(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o770); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-400 * 24 * time.Hour)
+	if err := os.Chtimes(sub, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := cleanupArchive(dir, 365, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 0 {
+		t.Fatalf("expected 0 removed, got %d", removed)
+	}
+	if _, err := os.Stat(sub); err != nil {
+		t.Errorf("subdirectory should have been kept: %v", err)
+	}
+}
+
+func TestCleanupArchiveMissingDir(t *testing.T) {
+	removed, err := cleanupArchive(filepath.Join(t.TempDir(), "does-not-exist"), 365, time.Now())
+	if err != nil {
+		t.Fatalf("missing dir should not error: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("expected 0 removed, got %d", removed)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ import (
 type Config struct {
 	Email   ConfigEmail   `toml:"email"`
 	Browser ConfigBrowser `toml:"browser"`
+	Archive ConfigArchive `toml:"archive"`
 }
 type ConfigEmail struct {
 	SMTPServer string `toml:"smtp_server"`
@@ -23,6 +24,11 @@ type ConfigEmail struct {
 }
 type ConfigBrowser struct {
 	ChromePath string `toml:"chrome_path"`
+}
+type ConfigArchive struct {
+	// RetentionDays controls how long processed articles are kept in the
+	// archive directory. 0 keeps files permanently.
+	RetentionDays int `toml:"retention_days"`
 }
 
 func loadConfig() error {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,12 +14,23 @@ Processed and debug artifacts are written under
 `~/.go-to-kindle/archive/`. `example_config.toml` shows the supported TOML
 shape without containing usable credentials.
 
+On startup the application also prunes the archive directory of files older
+than `archive.retention_days` (see [Settings](#settings)). The sweep is
+throttled to run at most once every 24 hours using a `~/.go-to-kindle/last_cleanup`
+marker file, so frequent launches incur no repeated filesystem work. Cleanup is
+best-effort: failures are logged but never block the application.
+
 ## Settings
 
 - `email.smtp_server`, `port`, `from`, `password`, and `to` configure SMTP
   delivery.
 - `browser.chrome_path` selects a Chrome or Chromium executable for headless
   retrieval.
+- `archive.retention_days` sets how long processed articles are retained in the
+  archive directory before automatic cleanup. It defaults to `365`; setting it
+  to `0` keeps files permanently. The default is applied even when an existing
+  config omits the `[archive]` section, so an explicit `0` is required to
+  disable cleanup.
 - The `--debug` CLI flag preserves intermediate retrieved or processed HTML in
   the archive directory.
 

--- a/example_config.toml
+++ b/example_config.toml
@@ -6,4 +6,7 @@ password = "123"
 to = "username@kindle.com"
 
 [browser]
-chrome_path = "/path/to/chrome" 
+chrome_path = "/path/to/chrome"
+
+[archive]
+retention_days = 365 # delete archived articles older than this; 0 keeps them forever

--- a/main.go
+++ b/main.go
@@ -29,6 +29,9 @@ var Conf Config = Config{
 	Browser: ConfigBrowser{
 		ChromePath: "",
 	},
+	Archive: ConfigArchive{
+		RetentionDays: 365,
+	},
 }
 
 var sendEmailWithAttachment = mail.SendEmailWithAttachment
@@ -55,6 +58,8 @@ func main() {
 	if err := loadConfig(); err != nil {
 		log.Fatalf("Failed to load config: %v", err)
 	}
+
+	maybeCleanupArchive(Conf.Archive.RetentionDays)
 
 	var modelOpts []ModelOption
 	if url != "" {


### PR DESCRIPTION
## Summary

Adds automatic cleanup of the `~/.go-to-kindle/archive/` directory, which previously grew without bound.

- New `archive.retention_days` config option, **default 365**; `0` keeps files permanently.
- On startup, files directly under the archive dir with a modtime older than the retention window are deleted (subdirectories are left alone).
- The sweep is **throttled to once per 24h** via a `~/.go-to-kindle/last_cleanup` marker file, so heavy users launching multiple times a day incur no repeated filesystem work.
- Cleanup is best-effort: failures are logged, never fatal.

## Default semantics

The default lives in the `Conf` literal and is applied *before* TOML unmarshal, which only overwrites keys present in the file. So:
- Absent `[archive]` section → 365 (existing users get the sensible default).
- Explicit `retention_days = 0` → keep forever.

New configs generated by `initConfig` write `retention_days = 365` explicitly.

## Tests

`cleanup_test.go` covers old-removed/new-kept, subdirectory skipping, and missing-directory handling.

Docs updated: `README.md`, `docs/configuration.md`, `example_config.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local filesystem cleanup under the app data directory only; failures are non-fatal and retention is user-configurable.
> 
> **Overview**
> Adds configurable **automatic pruning** of `~/.go-to-kindle/archive/` so the archive no longer grows without bound.
> 
> New **`[archive] retention_days`** (default **365**, **`0`** = keep forever) is wired through config and invoked from **`main`** after load via **`maybeCleanupArchive`**. The sweep deletes only **regular files** in the archive root older than the cutoff (by mtime), skips subdirectories, runs at most **once per 24h** using a **`last_cleanup`** marker, and is **best-effort** (errors logged; failed runs do not update the marker so cleanup retries on next startup).
> 
> Docs and **`example_config.toml`** document the setting; **`cleanup_test.go`** covers age filtering, subdir skipping, and missing archive dir.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36ded5976d183793eded17178ea8f55a764d6fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->