### PR TITLE
Prevent code-heavy articles from being sniffed as scripts

### DIFF
--- a/internal/repositories/file_repository.go
+++ b/internal/repositories/file_repository.go
@@ -87,9 +87,11 @@ func (r *localFileRepository) saveArticle(article *readability.Article, path str
 // fenced, indented, and inline code lands after rendering).
 var codeBlockRE = regexp.MustCompile(`(?s)(<code[^>]*>)(.*?)(</code>)`)
 
-// wordOrEntityRE matches either an existing HTML entity (left untouched) or a
-// word of source text (whose first letter we encode).
-var wordOrEntityRE = regexp.MustCompile(`&#?[0-9A-Za-z]+;|[A-Za-z][A-Za-z0-9_]*`)
+// codeTokenRE matches, in priority order, a nested tag (e.g. syntax-highlight
+// <span>) or an existing HTML entity — both left untouched — or a word of
+// source text whose first letter we encode. Matching tags and entities keeps us
+// from rewriting markup or attribute values inside highlighted code blocks.
+var codeTokenRE = regexp.MustCompile(`<[^>]*>|&#?[0-9A-Za-z]+;|[A-Za-z][A-Za-z0-9_]*`)
 
 // defuseCodeTokens rewrites the first letter of every word inside <code> blocks
 // as a numeric character reference (e.g. "from" -> "&#102;rom"). This renders
@@ -104,9 +106,9 @@ func defuseCodeTokens(content string) string {
 	return codeBlockRE.ReplaceAllStringFunc(content, func(block string) string {
 		m := codeBlockRE.FindStringSubmatch(block)
 		open, inner, closeTag := m[1], m[2], m[3]
-		encoded := wordOrEntityRE.ReplaceAllStringFunc(inner, func(tok string) string {
-			if strings.HasPrefix(tok, "&") {
-				return tok // existing entity such as &lt; or &#39; — leave intact
+		encoded := codeTokenRE.ReplaceAllStringFunc(inner, func(tok string) string {
+			if strings.HasPrefix(tok, "<") || strings.HasPrefix(tok, "&") {
+				return tok // nested tag or existing entity — leave intact
 			}
 			return "&#" + strconv.Itoa(int(tok[0])) + ";" + tok[1:]
 		})

--- a/internal/repositories/file_repository.go
+++ b/internal/repositories/file_repository.go
@@ -3,6 +3,8 @@ package repositories
 import (
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -31,6 +33,7 @@ type htmlData struct {
 const htmlTemplate = `<!DOCTYPE html>
 <html>
 <head>
+        <meta charset="utf-8">
         <title>{{.Title}}</title>
         <meta name="author" content="{{.Author}}">
        <style>
@@ -74,10 +77,41 @@ func (r *localFileRepository) saveArticle(article *readability.Article, path str
 	data := htmlData{
 		Title:       article.Title,
 		Author:      article.Byline,
-		Content:     article.Content,
+		Content:     defuseCodeTokens(article.Content),
 		DateContext: dateContext,
 	}
 	return t.Execute(file, data)
+}
+
+// codeBlockRE matches the inner text of each <code> element (which is where all
+// fenced, indented, and inline code lands after rendering).
+var codeBlockRE = regexp.MustCompile(`(?s)(<code[^>]*>)(.*?)(</code>)`)
+
+// wordOrEntityRE matches either an existing HTML entity (left untouched) or a
+// word of source text (whose first letter we encode).
+var wordOrEntityRE = regexp.MustCompile(`&#?[0-9A-Za-z]+;|[A-Za-z][A-Za-z0-9_]*`)
+
+// defuseCodeTokens rewrites the first letter of every word inside <code> blocks
+// as a numeric character reference (e.g. "from" -> "&#102;rom"). This renders
+// byte-for-byte identically to the reader but ensures no source-language keyword
+// (from/import/def/class/print/...) survives as literal ASCII in the file. That
+// prevents content sniffers (libmagic, and Amazon's Send-to-Kindle converter)
+// from misclassifying code-heavy documents as a script instead of HTML, which
+// would otherwise be delivered as plain text and rendered with raw tags visible.
+// The transform is content-agnostic: it defeats detection regardless of which
+// keywords appear, without enumerating any language.
+func defuseCodeTokens(content string) string {
+	return codeBlockRE.ReplaceAllStringFunc(content, func(block string) string {
+		m := codeBlockRE.FindStringSubmatch(block)
+		open, inner, closeTag := m[1], m[2], m[3]
+		encoded := wordOrEntityRE.ReplaceAllStringFunc(inner, func(tok string) string {
+			if strings.HasPrefix(tok, "&") {
+				return tok // existing entity such as &lt; or &#39; — leave intact
+			}
+			return "&#" + strconv.Itoa(int(tok[0])) + ";" + tok[1:]
+		})
+		return open + encoded + closeTag
+	})
 }
 
 // FormatDateContext returns the date line shown in the review screen and final article.


### PR DESCRIPTION
## Problem

Articles containing code render as **raw HTML tags** on Kindle. The cause is content sniffing: Amazon's Send-to-Kindle converter (like `libmagic`) scores source-language keywords (`from … import`, `def`, `class`, `print(`) and, past a threshold, classifies the file as a **script** rather than HTML — even though it starts with `<!DOCTYPE html>`. A file judged to be a script is delivered as plain text, so the Kindle prints the tags literally.

Confirmed empirically: a single `<code>` block with a few keywords flips `file`/libmagic from "HTML document" to "Python script."

## Fix

Two changes in the template layer (`file_repository.go`), the single chokepoint every article passes through regardless of source (markdown or web):

1. Add `<meta charset="utf-8">` — strengthens the HTML signal (was missing).
2. `defuseCodeTokens()` — rewrites the first letter of every word inside `<code>` blocks as a numeric character reference (`from` → `&#102;rom`).

Why it's principled, not a one-off:
- **Content-agnostic** — never enumerates languages/keywords; breaking every code word's first letter means no keyword survives as literal ASCII, so no sniffer regex can match, whatever the code is.
- **Byte-identical to the reader** — `&#102;` renders as "f"; copy-paste yields "f".
- **Entity-safe** — skips existing entities (`&lt;`, `&#39;`) so escaped code isn't corrupted.
- **Raw-string pass**, not a DOM round-trip (which would collapse the numeric entities back to plain letters and undo the fix).

## Verification

- `go build ./...` and `go vet` pass
- Existing `internal/repositories` and `postprocessing` tests pass
- Transform verified: keywords defused, existing entities preserved, prose outside code untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to HTML serialization on save; low blast radius, with minor risk of odd edge cases in unusual `<code>` markup.
> 
> **Overview**
> Code-heavy saved articles were sometimes classified as scripts by Send-to-Kindle/libmagic, so Kindle showed raw HTML instead of rendered pages. **All article HTML now passes through two template-layer changes in `file_repository.go`.**
> 
> The exported document head adds **`<meta charset="utf-8">`** to strengthen the HTML signal. Before write, **`defuseCodeTokens()`** runs on article body HTML: inside each `<code>` block it encodes the first letter of identifier-like words as numeric character references (e.g. `from` → `&#102;rom`), while skipping nested tags and existing entities so highlighted or escaped code is not corrupted. Prose outside `<code>` is unchanged; rendering and copy-paste should match the original text.
> 
> This is a content-agnostic workaround aimed at sniffers that key off literal keywords in code, not a language-specific blocklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 029f2c06cf0a133eaa17767078e84e391d787e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->